### PR TITLE
Bump to commit `a1e8ef5`

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -353,4 +353,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.17-v2
+        commit: a1e8ef5b22fcd6348807923943bd984494e594bf
+        


### PR DESCRIPTION
This pull request updates the source reference in the `io.github.pemsley.coot.yaml` file to use a specific commit instead of a release tag.