### PR TITLE
 Bump to Release-1.1.18

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -49,14 +49,14 @@ modules:
   - name: gemmi
     buildsystem: cmake-ninja
     config-opts:
-      - -DUSE_PYTHON=1
+      - -DUSE_PYTHON=ON
       - -DPYTHON_INSTALL_DIR=/app/lib/python3.12/site-packages
     build-options:
       cxxflags: "-fPIC -O2"
     sources:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
-        tag: v0.7.1
+        tag: v0.7.3
 
   - name: fftw2
     buildsystem: autotools
@@ -354,5 +354,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: a374e0364bbe7b9eb06b5c8302db38d24ae02007
+        tag: Release-1.1.18
         


### PR DESCRIPTION
This pull request updates the `io.github.pemsley.coot.yaml` file to improve module configuration and ensure compatibility with newer versions of dependencies. The changes primarily involve updating build options and source references.

### Updates to module configuration:

* Changed the `USE_PYTHON` flag from `1` to `ON` in the `gemmi` module to align with standard CMake conventions. (`[io.github.pemsley.coot.yamlL52-R59](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL52-R59)`)

### Updates to source references:

* Updated the `gemmi` module's source tag from `v0.7.1` to `v0.7.3` to use the latest version. (`[io.github.pemsley.coot.yamlL52-R59](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL52-R59)`)
* Changed the `coot` module's source reference from a specific commit (`a374e0364bbe7b9eb06b5c8302db38d24ae02007`) to a release tag (`Release-1.1.18`) for better version tracking. (`[io.github.pemsley.coot.yamlL357-R357](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL357-R357)`)