### PR TITLE
Automate upstream coot commit bump and update CI workflow

### DIFF
--- a/.github/workflows/upstream-coot-bump.yml
+++ b/.github/workflows/upstream-coot-bump.yml
@@ -1,0 +1,114 @@
+name: Bump upstream coot commit
+
+on:
+  schedule:
+    # Once a week (Sunday 05:00 UTC) per Flathub recommendation.
+    - cron: '0 5 * * 0'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    if: github.repository_owner == 'flathub'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [beta, alpha]
+    steps:
+      - name: Checkout ${{ matrix.target }}
+        # actions/checkout v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ matrix.target }}
+          fetch-depth: 0
+
+      - name: Resolve upstream HEAD of pemsley/coot
+        id: up
+        run: |
+          UP_SHA=$(git ls-remote https://github.com/pemsley/coot.git HEAD | awk '{print $1}')
+          if [ -z "$UP_SHA" ]; then
+            echo "Failed to resolve upstream HEAD" >&2
+            exit 1
+          fi
+          echo "sha=${UP_SHA}" >> "$GITHUB_OUTPUT"
+          echo "short=${UP_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Read currently pinned commit for the coot module
+        id: cur
+        run: |
+          CUR_SHA=$(python3 - <<'PY'
+          import re
+          text = open("io.github.pemsley.coot.yaml").read()
+          m = re.search(
+              r"- name:\s*coot\b.*?sources:\s*(?:.*?\n)*?\s*commit:\s*([0-9a-f]{40})",
+              text, re.S)
+          print(m.group(1) if m else "")
+          PY
+          )
+          if [ -z "$CUR_SHA" ]; then
+            echo "Could not find pinned commit for the coot module" >&2
+            exit 1
+          fi
+          echo "sha=${CUR_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Stop if already up-to-date
+        id: check
+        run: |
+          if [ "${{ steps.up.outputs.sha }}" = "${{ steps.cur.outputs.sha }}" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No new upstream commit on pemsley/coot."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rewrite commit field in manifest
+        if: steps.check.outputs.changed == 'true'
+        env:
+          NEW_SHA: ${{ steps.up.outputs.sha }}
+        run: |
+          python3 - <<'PY'
+          import os, re
+          path = "io.github.pemsley.coot.yaml"
+          new = os.environ["NEW_SHA"]
+          src = open(path).read()
+          pattern = re.compile(
+              r"(- name:\s*coot\b.*?sources:\s*(?:.*?\n)*?\s*commit:\s*)[0-9a-f]{40}",
+              re.S)
+          src2, n = pattern.subn(r"\g<1>" + new, src, count=1)
+          assert n == 1, "coot module commit: not found"
+          open(path, "w").write(src2)
+          PY
+
+      - name: Create Pull Request to ${{ matrix.target }}
+        if: steps.check.outputs.changed == 'true'
+        id: create-pr
+        # peter-evans/create-pull-request v7.0.8
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
+        with:
+          base: ${{ matrix.target }}
+          branch: bot/upstream-coot-${{ matrix.target }}
+          commit-message: |
+            coot: bump to ${{ steps.up.outputs.short }}
+          title: "coot: bump upstream to ${{ steps.up.outputs.short }} (${{ matrix.target }})"
+          body: |
+            Upstream https://github.com/pemsley/coot HEAD has new commits.
+            This PR updates the `commit:` field of the `coot` module in
+            `io.github.pemsley.coot.yaml`.
+
+            - old: `${{ steps.cur.outputs.sha }}`
+            - new: `${{ steps.up.outputs.sha }}`
+
+            Auto-generated. Target branch: `${{ matrix.target }}`.
+          labels: |
+            automated
+            upstream-bump
+          add-paths: |
+            io.github.pemsley.coot.yaml
+          delete-branch: true
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/upstream-coot-bump.yml
+++ b/.github/workflows/upstream-coot-bump.yml
@@ -2,8 +2,8 @@ name: Bump upstream coot commit
 
 on:
   schedule:
-    # Every 6 hours, at :17 to avoid the on-the-hour Actions congestion.
-    - cron: '17 */6 * * *'
+    # Every 1 hour, at :17 to avoid the on-the-hour Actions congestion.
+    - cron: '17 */1 * * *'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/upstream-coot-bump.yml
+++ b/.github/workflows/upstream-coot-bump.yml
@@ -27,34 +27,52 @@ jobs:
           ref: ${{ matrix.target }}
           fetch-depth: 0
 
-      - name: Resolve upstream HEAD of pemsley/coot
-        id: up
-        run: |
-          UP_SHA=$(git ls-remote https://github.com/pemsley/coot.git HEAD | awk '{print $1}')
-          if [ -z "$UP_SHA" ]; then
-            echo "Failed to resolve upstream HEAD" >&2
-            exit 1
-          fi
-          echo "sha=${UP_SHA}" >> "$GITHUB_OUTPUT"
-          echo "short=${UP_SHA::7}" >> "$GITHUB_OUTPUT"
-
-      - name: Read currently pinned commit for the coot module
+      - name: Read currently pinned ref for the coot module
         id: cur
         run: |
-          CUR_SHA=$(python3 - <<'PY'
+          mapfile -t CUR_DATA < <(python3 - <<'PY'
           import re
           text = open("io.github.pemsley.coot.yaml").read()
-          m = re.search(
-              r"- name:\s*coot\b.*?sources:\s*(?:.*?\n)*?\s*commit:\s*([0-9a-f]{40})",
-              text, re.S)
-          print(m.group(1) if m else "")
+          module = re.search(r"- name:\s*coot\b(.*?)(?=\n\s*-\s*name:|\Z)", text, re.S)
+          if not module:
+              print("")
+              print("")
+          else:
+              block = module.group(1)
+              tag = re.search(r"^\s*tag:\s*(\S+)", block, re.M)
+              commit = re.search(r"^\s*commit:\s*([0-9a-f]{40})", block, re.M)
+              print(tag.group(1) if tag else "")
+              print(commit.group(1) if commit else "")
           PY
           )
+          CUR_TAG="${CUR_DATA[0]}"
+          CUR_SHA="${CUR_DATA[1]}"
           if [ -z "$CUR_SHA" ]; then
             echo "Could not find pinned commit for the coot module" >&2
             exit 1
           fi
+          echo "tag=${CUR_TAG}" >> "$GITHUB_OUTPUT"
           echo "sha=${CUR_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve upstream ref of pemsley/coot
+        id: up
+        run: |
+          if [ -n "${{ steps.cur.outputs.tag }}" ]; then
+            UP_REF="refs/tags/${{ steps.cur.outputs.tag }}"
+            UP_SHA=$(git ls-remote https://github.com/pemsley/coot.git "${UP_REF}^{}" "${UP_REF}" | awk 'NR==1 {print $1}')
+            if [ -z "$UP_SHA" ]; then
+              echo "Failed to resolve upstream tag ${{ steps.cur.outputs.tag }}" >&2
+              exit 1
+            fi
+          else
+            UP_SHA=$(git ls-remote https://github.com/pemsley/coot.git HEAD | awk '{print $1}')
+            if [ -z "$UP_SHA" ]; then
+              echo "Failed to resolve upstream HEAD" >&2
+              exit 1
+            fi
+          fi
+          echo "sha=${UP_SHA}" >> "$GITHUB_OUTPUT"
+          echo "short=${UP_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Stop if already up-to-date
         id: check

--- a/.github/workflows/upstream-coot-bump.yml
+++ b/.github/workflows/upstream-coot-bump.yml
@@ -2,8 +2,8 @@ name: Bump upstream coot commit
 
 on:
   schedule:
-    # Once a week (Sunday 05:00 UTC) per Flathub recommendation.
-    - cron: '0 5 * * 0'
+    # Every 6 hours, at :17 to avoid the on-the-hour Actions congestion.
+    - cron: '17 */6 * * *'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/upstream-coot-bump.yml
+++ b/.github/workflows/upstream-coot-bump.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ matrix.target }}
-          fetch-depth: 0
 
       - name: Read currently pinned ref for the coot module
         id: cur

--- a/.github/workflows/upstream-coot-bump.yml
+++ b/.github/workflows/upstream-coot-bump.yml
@@ -97,7 +97,10 @@ jobs:
               r"(- name:\s*coot\b.*?sources:\s*(?:.*?\n)*?\s*commit:\s*)[0-9a-f]{40}",
               re.S)
           src2, n = pattern.subn(r"\g<1>" + new, src, count=1)
-          assert n == 1, "coot module commit: not found"
+          if n != 1:
+             raise SystemExit(
+                 f"Expected to rewrite exactly one coot module commit in {path}, but rewrote {n}."
+             )
           open(path, "w").write(src2)
           PY
 

--- a/.github/workflows/upstream-coot-bump.yml
+++ b/.github/workflows/upstream-coot-bump.yml
@@ -1,0 +1,134 @@
+name: Bump upstream coot commit
+
+on:
+  schedule:
+    # Every 1 hour, at :17 to avoid the on-the-hour Actions congestion.
+    - cron: '17 */1 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    if: github.repository_owner == 'flathub'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [beta, alpha]
+    steps:
+      - name: Checkout ${{ matrix.target }}
+        # actions/checkout v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ matrix.target }}
+
+      - name: Read currently pinned ref for the coot module
+        id: cur
+        run: |
+          mapfile -t CUR_DATA < <(python3 - <<'PY'
+          import re
+          text = open("io.github.pemsley.coot.yaml").read()
+          module = re.search(r"- name:\s*coot\b(.*?)(?=\n\s*-\s*name:|\Z)", text, re.S)
+          if not module:
+              print("")
+              print("")
+          else:
+              block = module.group(1)
+              tag = re.search(r"^\s*tag:\s*(\S+)", block, re.M)
+              commit = re.search(r"^\s*commit:\s*([0-9a-f]{40})", block, re.M)
+              print(tag.group(1) if tag else "")
+              print(commit.group(1) if commit else "")
+          PY
+          )
+          CUR_TAG="${CUR_DATA[0]}"
+          CUR_SHA="${CUR_DATA[1]}"
+          if [ -z "$CUR_SHA" ]; then
+            echo "Could not find pinned commit for the coot module" >&2
+            exit 1
+          fi
+          echo "tag=${CUR_TAG}" >> "$GITHUB_OUTPUT"
+          echo "sha=${CUR_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve upstream ref of pemsley/coot
+        id: up
+        run: |
+          if [ -n "${{ steps.cur.outputs.tag }}" ]; then
+            UP_REF="refs/tags/${{ steps.cur.outputs.tag }}"
+            UP_SHA=$(git ls-remote https://github.com/pemsley/coot.git "${UP_REF}^{}" "${UP_REF}" | awk 'NR==1 {print $1}')
+            if [ -z "$UP_SHA" ]; then
+              echo "Failed to resolve upstream tag ${{ steps.cur.outputs.tag }}" >&2
+              exit 1
+            fi
+          else
+            UP_SHA=$(git ls-remote https://github.com/pemsley/coot.git HEAD | awk '{print $1}')
+            if [ -z "$UP_SHA" ]; then
+              echo "Failed to resolve upstream HEAD" >&2
+              exit 1
+            fi
+          fi
+          echo "sha=${UP_SHA}" >> "$GITHUB_OUTPUT"
+          echo "short=${UP_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Stop if already up-to-date
+        id: check
+        run: |
+          if [ "${{ steps.up.outputs.sha }}" = "${{ steps.cur.outputs.sha }}" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No new upstream commit on pemsley/coot."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rewrite commit field in manifest
+        if: steps.check.outputs.changed == 'true'
+        env:
+          NEW_SHA: ${{ steps.up.outputs.sha }}
+        run: |
+          python3 - <<'PY'
+          import os, re
+          path = "io.github.pemsley.coot.yaml"
+          new = os.environ["NEW_SHA"]
+          src = open(path).read()
+          pattern = re.compile(
+              r"(- name:\s*coot\b.*?sources:\s*(?:.*?\n)*?\s*commit:\s*)[0-9a-f]{40}",
+              re.S)
+          src2, n = pattern.subn(r"\g<1>" + new, src, count=1)
+          if n != 1:
+             raise SystemExit(
+                 f"Expected to rewrite exactly one coot module commit in {path}, but rewrote {n}."
+             )
+          open(path, "w").write(src2)
+          PY
+
+      - name: Create Pull Request to ${{ matrix.target }}
+        if: steps.check.outputs.changed == 'true'
+        id: create-pr
+        # peter-evans/create-pull-request v7.0.8
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
+        with:
+          base: ${{ matrix.target }}
+          branch: bot/upstream-coot-${{ matrix.target }}
+          commit-message: |
+            coot: bump to ${{ steps.up.outputs.short }}
+          title: "coot: bump upstream to ${{ steps.up.outputs.short }} (${{ matrix.target }})"
+          body: |
+            Upstream https://github.com/pemsley/coot HEAD has new commits.
+            This PR updates the `commit:` field of the `coot` module in
+            `io.github.pemsley.coot.yaml`.
+
+            - old: `${{ steps.cur.outputs.sha }}`
+            - new: `${{ steps.up.outputs.sha }}`
+
+            Auto-generated. Target branch: `${{ matrix.target }}`.
+          labels: |
+            automated
+            upstream-bump
+          add-paths: |
+            io.github.pemsley.coot.yaml
+          delete-branch: true
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -656,8 +656,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.2
-        commit: 1a5900449e69ea1ef4607882d2f7e15912f7b6ec
+        commit: 3f3e083bc4040af4a6417d4042f3a0c0c99c7f39
         x-checker-data:
           type: git
           tag-pattern: ^Release-([0-9]+(?:\.[0-9]+)*)$

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -534,8 +534,8 @@ modules:
       - -DCMAKE_CXX_STANDARD=17
     sources:
       - type: archive
-        url: https://github.com/catchorg/Catch2/archive/refs/tags/v3.14.0.tar.gz
-        sha256: ba2a939efead3c833c499cf487e185762f419a71d30158cd1b43c6079c586490
+        url: https://github.com/catchorg/Catch2/archive/refs/tags/v3.15.0.tar.gz
+        sha256: 9650c55e497759cc39b977e45524bc8acb15256061c112080916ab6cb0b1ea66
         x-checker-data:
           type: anitya
           project-id: 7680


### PR DESCRIPTION
This pull request introduces an automated GitHub Actions workflow to keep the `coot` module's pinned upstream commit up-to-date in `io.github.pemsley.coot.yaml`, and also updates the Catch2 dependency to a newer version. The workflow checks for new upstream commits every hour and opens a pull request to update the pinned commit if needed.

**Automation:**

* Adds `.github/workflows/upstream-coot-bump.yml`, a scheduled GitHub Actions workflow that runs hourly and on manual dispatch to check for new upstream commits in `pemsley/coot`. If a new commit is found, it updates the `commit:` field in `io.github.pemsley.coot.yaml` and creates a PR targeting both `beta` and `alpha` branches.

**Dependency update:**

* Updates Catch2 in the manifest from version 3.14.0 to 3.15.0, including the new archive URL and SHA256 checksum in `io.github.pemsley.coot.yaml`.